### PR TITLE
Bring back the check to not write to the store during a fetchMore to fix data merging issues

### DIFF
--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -38,6 +38,10 @@ export function data(
   const constAction = action;
 
   if (isQueryResultAction(action)) {
+    if (action.fetchMoreForQueryId) {
+      return previousState;
+    }
+
     // XXX handle partial result due to errors
     if (!graphQLResultHasError(action.result)) {
       // XXX use immutablejs instead of cloning


### PR DESCRIPTION
Makes the previously failing test case now pass with proper data merging in the `fetchMore`.